### PR TITLE
Add hacking doc

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -1,0 +1,12 @@
+# Hacking
+
+## Install deps, dev-deps and run test.
+
+```
+git clone git@github.com:goombaio/dag.git
+cd dag
+export GO111MODULE=on  # ref: https://dave.cheney.net/2018/07/16/using-go-modules-with-travis-ci
+make deps
+make dev-deps
+make test
+```


### PR DESCRIPTION
## Description

Couldn't run make targets because I was running go 1.11 without `export GO111MODULE=on`.

## Approach

Adds a `HACKING.md` file which describes how to devel the package.