### PR TITLE
Implement Vertex.Value

### DIFF
--- a/dag_test.go
+++ b/dag_test.go
@@ -79,7 +79,7 @@ func TestDAG_AddEdge(t *testing.T) {
 	dag1 := dag.NewDAG()
 
 	vertex1 := dag.NewVertex("1", nil)
-	vertex2 := dag.NewVertex("2", nil)
+	vertex2 := dag.NewVertex("2", "two")
 
 	err := dag1.AddVertex(vertex1)
 	if err != nil {

--- a/example_dag_test.go
+++ b/example_dag_test.go
@@ -57,10 +57,10 @@ func ExampleDAG_vertices() {
 	// Output:
 	// DAG Vertices: 4 - Edges: 0
 	// Vertexs:
-	// ID: 1 - Parents: 0 - Children: 0
-	// ID: 2 - Parents: 0 - Children: 0
-	// ID: 3 - Parents: 0 - Children: 0
-	// ID: 4 - Parents: 0 - Children: 0
+	// ID: 1 - Parents: 0 - Children: 0 - Value: <nil>
+	// ID: 2 - Parents: 0 - Children: 0 - Value: <nil>
+	// ID: 3 - Parents: 0 - Children: 0 - Value: <nil>
+	// ID: 4 - Parents: 0 - Children: 0 - Value: <nil>
 }
 
 func ExampleDAG_edges() {
@@ -117,8 +117,8 @@ func ExampleDAG_edges() {
 	// Output:
 	// DAG Vertices: 4 - Edges: 3
 	// Vertexs:
-	// ID: 1 - Parents: 0 - Children: 1
-	// ID: 2 - Parents: 1 - Children: 1
-	// ID: 3 - Parents: 1 - Children: 1
-	// ID: 4 - Parents: 1 - Children: 0
+	// ID: 1 - Parents: 0 - Children: 1 - Value: <nil>
+	// ID: 2 - Parents: 1 - Children: 1 - Value: <nil>
+	// ID: 3 - Parents: 1 - Children: 1 - Value: <nil>
+	// ID: 4 - Parents: 1 - Children: 0 - Value: <nil>
 }

--- a/vertex.go
+++ b/vertex.go
@@ -26,6 +26,7 @@ import (
 // Vertex ...
 type Vertex struct {
 	ID       string
+	Value    interface{}
 	Parents  *orderedset.OrderedSet
 	Children *orderedset.OrderedSet
 }
@@ -36,6 +37,7 @@ func NewVertex(id string, value interface{}) *Vertex {
 		ID:       id,
 		Parents:  orderedset.NewOrderedSet(),
 		Children: orderedset.NewOrderedSet(),
+		Value:    value,
 	}
 
 	return v
@@ -44,7 +46,7 @@ func NewVertex(id string, value interface{}) *Vertex {
 // String implements stringer interface and prints an string representation
 // of this instance.
 func (v *Vertex) String() string {
-	result := fmt.Sprintf("ID: %s - Parents: %d - Children: %d\n", v.ID, v.Parents.Size(), v.Children.Size())
+	result := fmt.Sprintf("ID: %s - Parents: %d - Children: %d - Value: %v\n", v.ID, v.Parents.Size(), v.Children.Size(), v.Value)
 
 	return result
 }

--- a/vertex_test.go
+++ b/vertex_test.go
@@ -29,6 +29,9 @@ func TestVertex(t *testing.T) {
 	if v.ID == "" {
 		t.Fatalf("Vertex ID expected to be not empty string.\n")
 	}
+	if v.Value != nil {
+		t.Fatalf("Vertex Value expected to be nil.\n")
+	}
 }
 
 func TestVertex_Parents(t *testing.T) {
@@ -53,8 +56,29 @@ func TestVertex_String(t *testing.T) {
 	v := dag.NewVertex("1", nil)
 	vstr := v.String()
 
-	expected := "ID: 1 - Parents: 0 - Children: 0\n"
+	expected := "ID: 1 - Parents: 0 - Children: 0 - Value: <nil>\n"
 	if vstr != expected {
 		t.Fatalf("Vertex stringer expected to be %q but got %q\n", expected, vstr)
+	}
+}
+
+func TestVertex_String_WithStringValue(t *testing.T) {
+	v := dag.NewVertex("1", "one")
+	vstr := v.String()
+
+	expected := "ID: 1 - Parents: 0 - Children: 0 - Value: one\n"
+	if vstr != expected {
+		t.Fatalf("Vertex stringer expected to be %q but got %q\n", expected, vstr)
+	}
+}
+
+func TestVertex_WithStringValue(t *testing.T) {
+	v := dag.NewVertex("1", "one")
+
+	if v.ID == "" {
+		t.Fatalf("Vertex ID expected to be not empty string.\n")
+	}
+	if v.Value != "one" {
+		t.Fatalf("Vertex Value expected to be one.\n")
 	}
 }


### PR DESCRIPTION
## Description

value arg of `func NewVertex(id string, value interface{}) *Vertex {}` wasn't used.

## Approach

Added `Value` to the `Vertex` struct.  Added some test coverage for it.