### PR TITLE
WIP: Add basic tests for returning vertex value after adding it to DAG.

### DIFF
--- a/dag_test.go
+++ b/dag_test.go
@@ -185,6 +185,41 @@ func TestDAG_DeleteEdge(t *testing.T) {
 	}
 }
 
+func TestDAG_GetVertexValue(t *testing.T) {
+	dag1 := dag.NewDAG()
+
+	vertex1 := dag.NewVertex("1", nil)
+
+	err := dag1.AddVertex(vertex1)
+	if err != nil {
+		t.Fatalf("Can't add vertex to DAG: %s", err)
+	}
+
+	value, _ := dag1.Vertices.Get("1")
+
+	if value != nil {
+		t.Fatalf("Expected value to be nil but got %v.", value)
+	}
+}
+
+func TestDAG_GetVertexValueString(t *testing.T) {
+	dag1 := dag.NewDAG()
+
+	expected := "one"
+	vertex1 := dag.NewVertex("1", expected)
+
+	err := dag1.AddVertex(vertex1)
+	if err != nil {
+		t.Fatalf("Can't add vertex to DAG: %s", err)
+	}
+
+	value, _ := dag1.Vertices.Get("1")
+
+	if value != expected {
+		t.Fatalf("Expected value to be %v but got %v.", expected, value)
+	}
+}
+
 func TestDAG_Order(t *testing.T) {
 	dag1 := dag.NewDAG()
 


### PR DESCRIPTION
## Description

`dag.Vertices.Get(k)` returns pretty-printed string instead of the actual value.  I'm not exactly sure where the problem is at -- but I'm thinking it might be in the orderedMap lib.

This is WIP because my tests fail and I'm looking for a way to fix them.

I tried this too to no avail:

```
get, _ := dag1.Vertices.Get("1")
value := get.Value
```
.. but the result is: `get.Value undefined (type interface {} is interface with no methods)`

Please let me know how best to name these test methods.

## Approach

Demonstrates failure mode.

## Additional information

Failure mode:

```
go test -v github.com/goombaio/dag
=== RUN   TestDAG
--- PASS: TestDAG (0.00s)
=== RUN   TestDAG_AddVertex
--- PASS: TestDAG_AddVertex (0.00s)
=== RUN   TestDAG_DeleteVertex
--- PASS: TestDAG_DeleteVertex (0.00s)
=== RUN   TestDAG_AddEdge
--- PASS: TestDAG_AddEdge (0.00s)
=== RUN   TestDAG_AddEdge_FailsVertextDontExist
--- PASS: TestDAG_AddEdge_FailsVertextDontExist (0.00s)
=== RUN   TestDAG_AddEdge_FailsAlreadyExists
--- PASS: TestDAG_AddEdge_FailsAlreadyExists (0.00s)
=== RUN   TestDAG_DeleteEdge
--- PASS: TestDAG_DeleteEdge (0.00s)
=== RUN   TestDAG_GetVertexValue
--- FAIL: TestDAG_GetVertexValue (0.00s)
    dag_test.go:201: Expected value to be nil but got ID: 1 - Parents: 0 - Children: 0 - Value: <nil>
        .
=== RUN   TestDAG_GetVertexValueString
--- FAIL: TestDAG_GetVertexValueString (0.00s)
    dag_test.go:219: Expected value to be one but got ID: 1 - Parents: 0 - Children: 0 - Value: one
        .
=== RUN   TestDAG_Order
--- PASS: TestDAG_Order (0.00s)
=== RUN   TestDAG_Size
--- PASS: TestDAG_Size (0.00s)
=== RUN   TestDAG_SinkVertices
--- PASS: TestDAG_SinkVertices (0.00s)
=== RUN   TestDAG_SourceVertices
--- PASS: TestDAG_SourceVertices (0.00s)
=== RUN   TestDAG_Successors
--- PASS: TestDAG_Successors (0.00s)
=== RUN   TestDAG_Successors_VertexNotFound
--- PASS: TestDAG_Successors_VertexNotFound (0.00s)
=== RUN   TestDAG_Predecessors
--- PASS: TestDAG_Predecessors (0.00s)
=== RUN   TestDAG_Predecessors_VertexNotFound
--- PASS: TestDAG_Predecessors_VertexNotFound (0.00s)
=== RUN   TestVertex
--- PASS: TestVertex (0.00s)
=== RUN   TestVertex_Parents
--- PASS: TestVertex_Parents (0.00s)
=== RUN   TestVertex_Children
--- PASS: TestVertex_Children (0.00s)
=== RUN   TestVertex_Degree
--- PASS: TestVertex_Degree (0.00s)
=== RUN   TestVertex_InDegree
--- PASS: TestVertex_InDegree (0.00s)
=== RUN   TestVertex_OutDegree
--- PASS: TestVertex_OutDegree (0.00s)
=== RUN   TestVertex_String
--- PASS: TestVertex_String (0.00s)
=== RUN   TestVertex_String_WithStringValue
--- PASS: TestVertex_String_WithStringValue (0.00s)
=== RUN   TestVertex_WithStringValue
--- PASS: TestVertex_WithStringValue (0.00s)
=== RUN   ExampleDAG_vertices
--- PASS: ExampleDAG_vertices (0.00s)
=== RUN   ExampleDAG_edges
--- PASS: ExampleDAG_edges (0.00s)
FAIL
FAIL	github.com/goombaio/dag	0.006s
```