### PR TITLE
#32 Hide Vertices and add GetVertex method to DAG type.

### DIFF
--- a/dag.go
+++ b/dag.go
@@ -24,13 +24,13 @@ import (
 	"github.com/goombaio/orderedmap"
 )
 
-// DAG type implements a Directed acyclic graph data structure.
+// DAG type implements a Directed Acyclic Graph data structure.
 type DAG struct {
 	mu       sync.Mutex
 	Vertices orderedmap.OrderedMap
 }
 
-// NewDAG creates a new directed acyclic graph instance.
+// NewDAG creates a new Directed Acyclic Graph instance.
 func NewDAG() *DAG {
 	d := &DAG{
 		Vertices: *orderedmap.NewOrderedMap(),
@@ -49,7 +49,7 @@ func (d *DAG) AddVertex(v *Vertex) error {
 	return nil
 }
 
-// DeleteVertex deletes a verrtex and all the edges referencing it from the
+// DeleteVertex deletes a vertex and all the edges referencing it from the
 // graph.
 func (d *DAG) DeleteVertex(vertex *Vertex) error {
 	existsVertex := false
@@ -57,7 +57,7 @@ func (d *DAG) DeleteVertex(vertex *Vertex) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	// Check if vertexs exists.
+	// Check if vertices exists.
 	for _, v := range d.Vertices.Values() {
 		if v == vertex {
 			existsVertex = true
@@ -80,7 +80,7 @@ func (d *DAG) AddEdge(tailVertex *Vertex, headVertex *Vertex) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	// Check if vertexs exists.
+	// Check if vertices exists.
 	for _, vertex := range d.Vertices.Values() {
 		if vertex == tailVertex {
 			tailExists = true

--- a/dag.go
+++ b/dag.go
@@ -27,13 +27,13 @@ import (
 // DAG type implements a Directed Acyclic Graph data structure.
 type DAG struct {
 	mu       sync.Mutex
-	Vertices orderedmap.OrderedMap
+	vertices orderedmap.OrderedMap
 }
 
 // NewDAG creates a new Directed Acyclic Graph instance.
 func NewDAG() *DAG {
 	d := &DAG{
-		Vertices: *orderedmap.NewOrderedMap(),
+		vertices: *orderedmap.NewOrderedMap(),
 	}
 
 	return d
@@ -44,7 +44,7 @@ func (d *DAG) AddVertex(v *Vertex) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	d.Vertices.Put(v.ID, v)
+	d.vertices.Put(v.ID, v)
 
 	return nil
 }
@@ -58,7 +58,7 @@ func (d *DAG) DeleteVertex(vertex *Vertex) error {
 	defer d.mu.Unlock()
 
 	// Check if vertices exists.
-	for _, v := range d.Vertices.Values() {
+	for _, v := range d.vertices.Values() {
 		if v == vertex {
 			existsVertex = true
 		}
@@ -67,7 +67,7 @@ func (d *DAG) DeleteVertex(vertex *Vertex) error {
 		return fmt.Errorf("Vertex with ID %v not found", vertex.ID)
 	}
 
-	d.Vertices.Remove(vertex.ID)
+	d.vertices.Remove(vertex.ID)
 
 	return nil
 }
@@ -81,7 +81,7 @@ func (d *DAG) AddEdge(tailVertex *Vertex, headVertex *Vertex) error {
 	defer d.mu.Unlock()
 
 	// Check if vertices exists.
-	for _, vertex := range d.Vertices.Values() {
+	for _, vertex := range d.vertices.Values() {
 		if vertex == tailVertex {
 			tailExists = true
 		}
@@ -122,9 +122,23 @@ func (d *DAG) DeleteEdge(tailVertex *Vertex, headVertex *Vertex) error {
 	return nil
 }
 
+// Return a vertex from the graph given a vertex ID.
+func (d *DAG) GetVertex(id interface{}) (*Vertex, error) {
+	var vertex *Vertex
+
+	v, found := d.vertices.Get(id)
+	if !found {
+		return vertex, fmt.Errorf("vertex %s not found in the graph", id)
+	}
+
+	vertex = v.(*Vertex)
+
+	return vertex, nil
+}
+
 // Order return the number of vertices in the graph.
 func (d *DAG) Order() int {
-	numVertices := d.Vertices.Size()
+	numVertices := d.vertices.Size()
 
 	return numVertices
 }
@@ -132,7 +146,7 @@ func (d *DAG) Order() int {
 // Size return the number of edges in the graph.
 func (d *DAG) Size() int {
 	numEdges := 0
-	for _, vertex := range d.Vertices.Values() {
+	for _, vertex := range d.vertices.Values() {
 		numEdges = numEdges + vertex.(*Vertex).Children.Size()
 	}
 
@@ -143,7 +157,7 @@ func (d *DAG) Size() int {
 func (d *DAG) SinkVertices() []*Vertex {
 	var sinkVertices []*Vertex
 
-	for _, vertex := range d.Vertices.Values() {
+	for _, vertex := range d.vertices.Values() {
 		if vertex.(*Vertex).Children.Size() == 0 {
 			sinkVertices = append(sinkVertices, vertex.(*Vertex))
 		}
@@ -156,7 +170,7 @@ func (d *DAG) SinkVertices() []*Vertex {
 func (d *DAG) SourceVertices() []*Vertex {
 	var sourceVertices []*Vertex
 
-	for _, vertex := range d.Vertices.Values() {
+	for _, vertex := range d.vertices.Values() {
 		if vertex.(*Vertex).Parents.Size() == 0 {
 			sourceVertices = append(sourceVertices, vertex.(*Vertex))
 		}
@@ -169,8 +183,8 @@ func (d *DAG) SourceVertices() []*Vertex {
 func (d *DAG) Successors(vertex *Vertex) ([]*Vertex, error) {
 	var successors []*Vertex
 
-	_, found := d.Vertices.Get(vertex.ID)
-	if !found {
+	_, found := d.GetVertex(vertex.ID)
+	if found != nil {
 		return successors, fmt.Errorf("vertex %s not found in the graph", vertex.ID)
 	}
 
@@ -185,8 +199,8 @@ func (d *DAG) Successors(vertex *Vertex) ([]*Vertex, error) {
 func (d *DAG) Predecessors(vertex *Vertex) ([]*Vertex, error) {
 	var predecessors []*Vertex
 
-	_, found := d.Vertices.Get(vertex.ID)
-	if !found {
+	_, found := d.GetVertex(vertex.ID)
+	if found != nil {
 		return predecessors, fmt.Errorf("vertex %s not found in the graph", vertex.ID)
 	}
 
@@ -202,7 +216,7 @@ func (d *DAG) Predecessors(vertex *Vertex) ([]*Vertex, error) {
 func (d *DAG) String() string {
 	result := fmt.Sprintf("DAG Vertices: %d - Edges: %d\n", d.Order(), d.Size())
 	result += fmt.Sprintf("Vertices:\n")
-	for _, vertex := range d.Vertices.Values() {
+	for _, vertex := range d.vertices.Values() {
 		vertex = vertex.(*Vertex)
 		result += fmt.Sprintf("%s", vertex)
 	}

--- a/dag_test.go
+++ b/dag_test.go
@@ -26,8 +26,8 @@ import (
 func TestDAG(t *testing.T) {
 	d := dag.NewDAG()
 
-	if d.Vertices.Size() != 0 {
-		t.Fatalf("DAG number of vertices expected to be 0 but got %d", d.Vertices.Size())
+	if d.Order() != 0 {
+		t.Fatalf("DAG number of vertices expected to be 0 but got %d", d.Order())
 	}
 }
 
@@ -41,8 +41,8 @@ func TestDAG_AddVertex(t *testing.T) {
 		t.Fatalf("Can't add vertex to DAG: %s", err)
 	}
 
-	if dag1.Vertices.Size() != 1 {
-		t.Fatalf("DAG number of vertices expected to be 1 but got %d", dag1.Vertices.Size())
+	if dag1.Order() != 1 {
+		t.Fatalf("DAG number of vertices expected to be 1 but got %d", dag1.Order())
 	}
 }
 
@@ -56,8 +56,8 @@ func TestDAG_DeleteVertex(t *testing.T) {
 		t.Fatalf("Can't add vertex to DAG")
 	}
 
-	if dag1.Vertices.Size() != 1 {
-		t.Fatalf("DAG number of vertices expected to be 1 but got %d", dag1.Vertices.Size())
+	if dag1.Order() != 1 {
+		t.Fatalf("DAG number of vertices expected to be 1 but got %d", dag1.Order())
 	}
 
 	err = dag1.DeleteVertex(vertex1)
@@ -65,8 +65,8 @@ func TestDAG_DeleteVertex(t *testing.T) {
 		t.Fatalf("Can't delete vertex from DAG: %s", err)
 	}
 
-	if dag1.Vertices.Size() != 0 {
-		t.Fatalf("DAG number of vertices expected to be 0 but got %d", dag1.Vertices.Size())
+	if dag1.Order() != 0 {
+		t.Fatalf("DAG number of vertices expected to be 0 but got %d", dag1.Order())
 	}
 
 	err = dag1.DeleteVertex(vertex1)
@@ -182,6 +182,34 @@ func TestDAG_DeleteEdge(t *testing.T) {
 	size = dag1.Size()
 	if size != 0 {
 		t.Fatalf("Dag expected to have 0 edges but got %d", size)
+	}
+}
+
+func TestDAG_GetVertex(t *testing.T) {
+	dag1 := dag.NewDAG()
+
+	vertex1 := dag.NewVertex("1", "one")
+	vertex2 := dag.NewVertex("2", 2)
+
+	err := dag1.AddVertex(vertex1)
+	if err != nil {
+		t.Fatalf("Can't add vertex1 to DAG: %s", err)
+	}
+	err = dag1.AddVertex(vertex2)
+	if err != nil {
+		t.Fatalf("Can't add vertex2 to DAG: %s", err)
+	}
+
+	v1, _ := dag1.GetVertex("1")
+	v2, _ := dag1.GetVertex("2")
+
+	expected1 := "one"
+	expected2 := 2
+	if v1.Value != expected1 {
+		t.Fatalf("Expected value1 to be %q but got %v.", expected1, v1.Value)
+	}
+	if v1.Value != expected1 {
+		t.Fatalf("Expected value2 to be %q but got %v.", expected2, v2.Value)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/goombaio/dag
 
 require (
-	github.com/goombaio/orderedmap v0.0.0-20180914055104-17aec6e5c534
-	github.com/goombaio/orderedset v0.0.0-20180914055012-52cd141747e3
+	github.com/goombaio/orderedmap v0.0.0-20180914223936-0f08a0ff7177
+	github.com/goombaio/orderedset v0.0.0-20180914224700-b7aeb2c119e3
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,4 @@
-github.com/goombaio/orderedmap v0.0.0-20180909154953-8a7ec76cbbe3/go.mod h1:YKu81H3RSd1cFh0d7NhvUoTtUC9IY/vBX0WUQb1/o4Y=
-github.com/goombaio/orderedmap v0.0.0-20180914055104-17aec6e5c534 h1:900x/Rd8UHHF2J1Ca2tIspnjiqSCa4kCKIkRM502Vc4=
-github.com/goombaio/orderedmap v0.0.0-20180914055104-17aec6e5c534/go.mod h1:YKu81H3RSd1cFh0d7NhvUoTtUC9IY/vBX0WUQb1/o4Y=
-github.com/goombaio/orderedset v0.0.0-20180914055012-52cd141747e3 h1:yQVltnuJPTyUTQ6wYYN0SmMDLvds76oVQZu1KRYFMu4=
-github.com/goombaio/orderedset v0.0.0-20180914055012-52cd141747e3/go.mod h1:R1TTMcaEzt9BEIx7zMybVI+SYaxlsOcbUKtxBKcus10=
+github.com/goombaio/orderedmap v0.0.0-20180914223936-0f08a0ff7177 h1:ir16lv3x1rtOU6LKoyoBzI3Mch91vlHOlSJIh75ZERU=
+github.com/goombaio/orderedmap v0.0.0-20180914223936-0f08a0ff7177/go.mod h1:YKu81H3RSd1cFh0d7NhvUoTtUC9IY/vBX0WUQb1/o4Y=
+github.com/goombaio/orderedset v0.0.0-20180914224700-b7aeb2c119e3 h1:Qs8WhlmQVaFSZxiPl9QXoK24ghnDYNPuJJx3PvueoAY=
+github.com/goombaio/orderedset v0.0.0-20180914224700-b7aeb2c119e3/go.mod h1:mABw6LHASk7y0G0Ep5+3gGHkVbuqokP7TlytYRtj5aQ=


### PR DESCRIPTION
## Description

Hide Vertices and add GetVertex method to DAG type.

## Approach

Implement the above and change external calls of `d.Vertices.Size()` to `d.Order()`.

## Additional information

Fixed a couple of minor comment issues.

Related: 
- #31 
- #32 
