### PR TITLE
DeleteEdge: remove tail from parent list of head vertex

### DIFF
--- a/dag.go
+++ b/dag.go
@@ -118,6 +118,11 @@ func (d *DAG) DeleteEdge(tailVertex *Vertex, headVertex *Vertex) error {
 			tailVertex.Children.Remove(childVertex)
 		}
 	}
+	for _, parentVertex := range headVertex.Parents.Values() {
+		if parentVertex == tailVertex {
+			headVertex.Parents.Remove(parentVertex)
+		}
+	}
 
 	return nil
 }

--- a/dag_test.go
+++ b/dag_test.go
@@ -183,6 +183,16 @@ func TestDAG_DeleteEdge(t *testing.T) {
 	if size != 0 {
 		t.Fatalf("Dag expected to have 0 edges but got %d", size)
 	}
+
+	outDegree := vertex1.OutDegree()
+	if outDegree != 0 {
+		t.Fatalf("Vertex %s expected to have 0 outgoing edges but got %d", vertex1.ID, outDegree)
+	}
+	inDegree := vertex2.InDegree()
+	if inDegree != 0 {
+		t.Fatalf("Vertex %s expected to have 0 incoming edges but got %d", vertex2.ID, inDegree)
+	}
+
 }
 
 func TestDAG_GetVertex(t *testing.T) {


### PR DESCRIPTION
Makes DeleteEdge the inverse of AddEdge

## Description

AddEdge updates the children and parents set of the head and tail vertex, while DeleteEdge only removes the edge from the children of the tail vertex. This makes it difficult to use DeleteEdge as it does not fully remove the edge from the dag. In order to implement a topological sort, I needed to first implement my own DeleteEdge which shouldn't be necessary.

## Approach

Fix the glitch by updating the parent list of the headVertex.

I followed the existing code in DeleteEdge that searches the entire set before calling remove(), but this is redundant as OrderedSet will repeat the same operation afaict. I can adjust that if desired.
